### PR TITLE
fixing cache limit

### DIFF
--- a/src/ui_ditto.py
+++ b/src/ui_ditto.py
@@ -48,7 +48,7 @@ def get_config():
 
 
 @st.cache_data(
-    max_entries=50
+    max_entries=5
 )  # limit number of genes loaded in cache to 50 to prevent reaching memory limits
 def load_gene_data(gene_name):
     ditto_gene_preds_df = pd.read_csv(


### PR DESCRIPTION
When running memory profiler `psrecord`, looks like a memory leak from the caching strategy (we used 50) used for loading gene data. Here's the profile plot -
![plot](https://user-images.githubusercontent.com/41593805/227306780-5716d5ca-14c8-4e0e-a7ec-f72179b966cd.png)

We decided to reduce it to 5 to reduce the memory leak. Here's the profile after - 
![plot1](https://user-images.githubusercontent.com/41593805/227307985-6ebfba47-1244-4990-9736-a0aafd108a4e.png)


This fixes #8 !